### PR TITLE
support datatables in test mode

### DIFF
--- a/src/tagui
+++ b/src/tagui
@@ -324,7 +324,7 @@ fi
 
 # check if test mode is enabled and run casperjs accordingly, before sending finish signal if integrations are active
 if [ "$tagui_test_mode" == false ]; then "$CASPERJS_EXECUTABLE" "$1".js $params$api | tee -a "$1".log
-else export tagui_test_mode=true; "$CASPERJS_EXECUTABLE" test "$1".js $params$api --xunit="$1".xml | tee -a "$1".log; fi
+else export tagui_test_mode=true; "$CASPERJS_EXECUTABLE" test "$1".js $api --xunit="$1".xml | tee -a "$1".log; fi
 # checking for existence of files is important, otherwise in loops integrations will run even without enabling
 if [ -f "tagui_r/tagui_r.in" ]; then echo "finish" > tagui_r/tagui_r.in; fi
 if [ -f "tagui_py/tagui_py.in" ]; then echo "finish" > tagui_py/tagui_py.in; fi

--- a/src/tagui.cmd
+++ b/src/tagui.cmd
@@ -618,7 +618,7 @@ rem check if test mode is enabled and run casperjs accordingly, before sending f
 if %tagui_test_mode%==false (
 	casperjs "%flow_file%.js" %params%!api! | tee -a "%flow_file%.log"
 ) else (
-	casperjs test "%flow_file%.js" %params%!api! --xunit="%flow_file%.xml" | tee -a "%flow_file%.log"
+	casperjs test "%flow_file%.js" !api! --xunit="%flow_file%.xml" | tee -a "%flow_file%.log"
 )
 rem checking for existence of files is important, otherwise in loops integrations will run even without enabling
 if exist "tagui_r\tagui_r.in" echo finish > tagui_r\tagui_r.in


### PR DESCRIPTION
details of issue here - https://github.com/kelaberetiv/TagUI/issues/348

when datatable is used with test option, execution hangs after the first iteration. this is because casperjs test mode treats every parameter as in input file to test. when the datatable parameter is passed to casperjs it hangs because it is not a valid test js file. modified tagui and tagui.cmd to not pass parameters to casperjs in test mode.

technical details here - http://docs.casperjs.org/en/latest/testing.html#arguments

`The casperjs test command will treat every passed argument as file or directory paths containing tests. It will recursively scan any passed directory to search for *.js or *.coffee files and add them to the stack.`